### PR TITLE
feat/get-store-api #65 #76

### DIFF
--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/datasource/BaseDataSource.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/datasource/BaseDataSource.kt
@@ -2,12 +2,14 @@ package com.bravepeople.onggiyonggi.data.datasource
 
 import com.bravepeople.onggiyonggi.data.request_dto.RequestLoginDto
 import com.bravepeople.onggiyonggi.data.request_dto.RequestSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseCheckSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseLoginDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseSignUpDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
 
 interface BaseDataSource {
     // signup
@@ -28,22 +30,32 @@ interface BaseDataSource {
         requestLoginDto: RequestLoginDto
     ): ResponseLoginDto
 
+    // home
+    suspend fun getStore(
+        token:String,
+        latitude:Double,
+        longitude:Double,
+        radius:Int
+    ):ResponseGetStoreDto
+
     // character
     suspend fun getPet(
         token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     suspend fun randomPet(
         token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     suspend fun levelUp(
         token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     suspend fun addMax(
         token:String,
-    ):ResponseAddMaxDto
+    ): ResponseAddMaxDto
 
-    suspend fun collection(token:String):ResponseCollectionDto
+    suspend fun allCharacter(token:String):ResponseAllCharacterDto
+
+    suspend fun collection(token:String): ResponseCollectionDto
 }

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/datasourceImpl/BaseDataSourceImpl.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/datasourceImpl/BaseDataSourceImpl.kt
@@ -3,12 +3,14 @@ package com.bravepeople.onggiyonggi.data.datasourceImpl
 import com.bravepeople.onggiyonggi.data.datasource.BaseDataSource
 import com.bravepeople.onggiyonggi.data.request_dto.RequestLoginDto
 import com.bravepeople.onggiyonggi.data.request_dto.RequestSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseCheckSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseLoginDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseSignUpDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
 import com.bravepeople.onggiyonggi.data.service.BaseService
 import javax.inject.Inject
 
@@ -23,10 +25,19 @@ class BaseDataSourceImpl @Inject constructor(
     // login
     override suspend fun login(requestLoginDto: RequestLoginDto): ResponseLoginDto = baseService.login(requestLoginDto)
 
+    // home
+    override suspend fun getStore(
+        token: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Int
+    ): ResponseGetStoreDto = baseService.getStore(token, latitude, longitude, radius)
+
     // character
     override suspend fun getPet(token:String): ResponseGetPetDto = baseService.getPet(token)
     override suspend fun randomPet(token: String): ResponseGetPetDto = baseService.randomPet(token)
     override suspend fun levelUp(token: String): ResponseGetPetDto = baseService.levelUp(token)
     override suspend fun addMax(token: String): ResponseAddMaxDto = baseService.addMax(token)
+    override suspend fun allCharacter(token: String): ResponseAllCharacterDto = baseService.allCharacter(token)
     override suspend fun collection(token: String): ResponseCollectionDto = baseService.collection(token)
 }

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/repositoryImpl/BaseRepositoryImpl.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/repositoryImpl/BaseRepositoryImpl.kt
@@ -3,12 +3,14 @@ package com.bravepeople.onggiyonggi.data.repositoryImpl
 import com.bravepeople.onggiyonggi.data.datasource.BaseDataSource
 import com.bravepeople.onggiyonggi.data.request_dto.RequestLoginDto
 import com.bravepeople.onggiyonggi.data.request_dto.RequestSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseCheckSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseLoginDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseSignUpDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
 import com.bravepeople.onggiyonggi.domain.repository.BaseRepository
 import timber.log.Timber
 import javax.inject.Inject
@@ -54,6 +56,20 @@ class BaseRepositoryImpl @Inject constructor(
         }
     }
 
+    // home
+    override suspend fun getStore(
+        token: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Int
+    ): Result<ResponseGetStoreDto> {
+        return runCatching {
+            baseDataSource.getStore(token, latitude, longitude, radius)
+        }.onFailure {
+            Timber.e("base repository get store fail!!: $it")
+        }
+    }
+
     // character
     override suspend fun getPet(token: String): Result<ResponseGetPetDto> {
         return runCatching {
@@ -84,6 +100,14 @@ class BaseRepositoryImpl @Inject constructor(
             baseDataSource.collection(token)
         }.onFailure {
             Timber.e("base repository collection fail!!: $it")
+        }
+    }
+
+    override suspend fun allCharacter(token: String): Result<ResponseAllCharacterDto> {
+        return runCatching {
+            baseDataSource.allCharacter(token)
+        }.onFailure {
+            Timber.e("base repository all character fail!!: $it")
         }
     }
 

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/ResponseGetStoreDto.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/ResponseGetStoreDto.kt
@@ -1,0 +1,30 @@
+package com.bravepeople.onggiyonggi.data.response_dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGetStoreDto(
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<StoreData>
+) {
+    @Serializable
+    data class StoreData(
+        @SerialName("id")
+        val id: Int,
+        @SerialName("storeRank")
+        val storeRank: String,
+        @SerialName("storeType")
+        val storeType: String,
+        @SerialName("latitude")
+        val latitude: Double,
+        @SerialName("longitude")
+        val longitude: Double
+    )
+}

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseAddMaxDto.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseAddMaxDto.kt
@@ -1,6 +1,5 @@
-package com.bravepeople.onggiyonggi.data.response_dto
+package com.bravepeople.onggiyonggi.data.response_dto.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto.Data
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseAllCharacterDto.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseAllCharacterDto.kt
@@ -1,0 +1,30 @@
+package com.bravepeople.onggiyonggi.data.response_dto.character
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseAllCharacterDto (
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("status")
+    val status: String,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<CharacterDetail>
+){
+    @Serializable
+    data class CharacterDetail(
+        @SerialName("id")
+        val id: Int,
+        @SerialName("name")
+        val name: String,
+        @SerialName("description")
+        val description: String,
+        @SerialName("story")
+        val story: String,
+        @SerialName("imageURL")
+        val imageURL: String
+    )
+}

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseCollectionDto.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseCollectionDto.kt
@@ -1,4 +1,4 @@
-package com.bravepeople.onggiyonggi.data.response_dto
+package com.bravepeople.onggiyonggi.data.response_dto.character
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
@@ -7,33 +7,28 @@ import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
-data class ResponseGetPetDto(
+data class ResponseCollectionDto(
     @SerialName("success")
-    val success: Boolean,
+    val success:Boolean,
     @SerialName("status")
-    val status: String,
+    val status:String,
     @SerialName("message")
-    val message: String,
+    val message:String,
     @SerialName("data")
-    val data: Data?
-):Parcelable {
+    val data:List<Data>
+
+):Parcelable{
     @Parcelize
     @Serializable
     data class Data(
         @SerialName("id")
         val id: Int,
-        @SerialName("naturalMonumentCharacter")
-        val naturalMonumentCharacter: NaturalMonumentCharacter,
-        @SerialName("affinity")
-        val affinity: Float,
-    ):Parcelable {
+        @SerialName("characterResponseDto")
+        val characterResponseDto: CharacterResponseDto
+    ):Parcelable{
         @Parcelize
         @Serializable
-        data class NaturalMonumentCharacter(
-            @SerialName("createdAt")
-            val createdAt: String?,
-            @SerialName("updatedAt")
-            val updatedAt: String?,
+        data class CharacterResponseDto(
             @SerialName("id")
             val id: Int,
             @SerialName("name")
@@ -43,7 +38,7 @@ data class ResponseGetPetDto(
             @SerialName("story")
             val story: String,
             @SerialName("imageURL")
-            val imageUrl: String
+            val imageURL: String
         ):Parcelable
     }
 }

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseGetPetDto.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/response_dto/character/ResponseGetPetDto.kt
@@ -1,4 +1,4 @@
-package com.bravepeople.onggiyonggi.data.response_dto
+package com.bravepeople.onggiyonggi.data.response_dto.character
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
@@ -7,28 +7,33 @@ import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
-data class ResponseCollectionDto(
+data class ResponseGetPetDto(
     @SerialName("success")
-    val success:Boolean,
+    val success: Boolean,
     @SerialName("status")
-    val status:String,
+    val status: String,
     @SerialName("message")
-    val message:String,
+    val message: String,
     @SerialName("data")
-    val data:List<Data>
-
-):Parcelable{
+    val data: Data?
+):Parcelable {
     @Parcelize
     @Serializable
     data class Data(
         @SerialName("id")
         val id: Int,
-        @SerialName("characterResponseDto")
-        val characterResponseDto: CharacterResponseDto
-    ):Parcelable{
+        @SerialName("naturalMonumentCharacter")
+        val naturalMonumentCharacter: NaturalMonumentCharacter,
+        @SerialName("affinity")
+        val affinity: Float,
+    ):Parcelable {
         @Parcelize
         @Serializable
-        data class CharacterResponseDto(
+        data class NaturalMonumentCharacter(
+            @SerialName("createdAt")
+            val createdAt: String?,
+            @SerialName("updatedAt")
+            val updatedAt: String?,
             @SerialName("id")
             val id: Int,
             @SerialName("name")
@@ -38,7 +43,7 @@ data class ResponseCollectionDto(
             @SerialName("story")
             val story: String,
             @SerialName("imageURL")
-            val imageURL: String
+            val imageUrl: String
         ):Parcelable
     }
 }

--- a/app/src/main/java/com/bravepeople/onggiyonggi/data/service/BaseService.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/data/service/BaseService.kt
@@ -2,12 +2,14 @@ package com.bravepeople.onggiyonggi.data.service
 
 import com.bravepeople.onggiyonggi.data.request_dto.RequestLoginDto
 import com.bravepeople.onggiyonggi.data.request_dto.RequestSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseCheckSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseLoginDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseSignUpDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -37,29 +39,44 @@ interface BaseService {
         @Body requestLoginDto: RequestLoginDto
     ):ResponseLoginDto
 
+    // home
+    @GET("/store/")
+    suspend fun getStore(
+        @Header ("Authorization") token:String,
+        @Query("latitude") latitude:Double,
+        @Query("longitude") longitude:Double,
+        @Query("radius") radius:Int,
+    ):ResponseGetStoreDto
+
+
     // character
     @GET("/pet/")
     suspend fun getPet(
         @Header ("Authorization") token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     @POST("/pet/")
     suspend fun randomPet(
         @Header ("Authorization") token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     @POST("/pet/levelup")
     suspend fun levelUp(
         @Header ("Authorization") token:String,
-    ):ResponseGetPetDto
+    ): ResponseGetPetDto
 
     @POST("/collection/")
     suspend fun addMax(
         @Header ("Authorization") token:String,
-    ):ResponseAddMaxDto
+    ): ResponseAddMaxDto
+
+    @GET("/character/")
+    suspend fun allCharacter(
+        @Header ("Authorization") token:String,
+    ):ResponseAllCharacterDto
 
     @GET("/collection/")
     suspend fun collection(
         @Header ("Authorization") token:String,
-    ):ResponseCollectionDto
+    ): ResponseCollectionDto
 }

--- a/app/src/main/java/com/bravepeople/onggiyonggi/domain/repository/BaseRepository.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/domain/repository/BaseRepository.kt
@@ -1,11 +1,13 @@
 package com.bravepeople.onggiyonggi.domain.repository
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseCheckSignUpDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseLoginDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
 import com.bravepeople.onggiyonggi.data.response_dto.ResponseSignUpDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
 
 interface BaseRepository {
     // signup
@@ -29,6 +31,14 @@ interface BaseRepository {
         password:String,
     ):Result<ResponseLoginDto>
 
+    // home
+    suspend fun getStore(
+        token:String,
+        latitude:Double,
+        longitude:Double,
+        radius:Int,
+    ):Result<ResponseGetStoreDto>
+
     // character
     suspend fun getPet(
         token:String,
@@ -45,6 +55,10 @@ interface BaseRepository {
     suspend fun addMax(
         token:String,
     ):Result<ResponseAddMaxDto>
+
+    suspend fun allCharacter(
+        token:String,
+    ):Result<ResponseAllCharacterDto>
 
     suspend fun collection(
         token:String,

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/AddMaxState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/AddMaxState.kt
@@ -1,7 +1,6 @@
 package com.bravepeople.onggiyonggi.extension.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAddMaxDto
 
 sealed class AddMaxState {
     data object Loading: AddMaxState()

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/AllCharacterState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/AllCharacterState.kt
@@ -1,0 +1,9 @@
+package com.bravepeople.onggiyonggi.extension.character
+
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
+
+sealed class AllCharacterState {
+    data object Loading: AllCharacterState()
+    data class Success(val characterDto: ResponseAllCharacterDto): AllCharacterState()
+    data class Error(val message:String): AllCharacterState()
+}

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/CollectionState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/CollectionState.kt
@@ -1,7 +1,6 @@
 package com.bravepeople.onggiyonggi.extension.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseAddMaxDto
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 
 sealed class CollectionState {
     data object Loading: CollectionState()

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/GetPetState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/GetPetState.kt
@@ -1,6 +1,6 @@
 package com.bravepeople.onggiyonggi.extension.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
 
 sealed class GetPetState {
     data object Loading: GetPetState()

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/LevelUpState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/LevelUpState.kt
@@ -1,6 +1,6 @@
 package com.bravepeople.onggiyonggi.extension.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
 
 sealed class LevelUpState {
     data object Loading: LevelUpState()

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/RandomPetState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/character/RandomPetState.kt
@@ -1,6 +1,6 @@
 package com.bravepeople.onggiyonggi.extension.character
 
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
 
 sealed class RandomPetState {
     data object Loading: RandomPetState()

--- a/app/src/main/java/com/bravepeople/onggiyonggi/extension/home/GetStoreState.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/extension/home/GetStoreState.kt
@@ -1,0 +1,11 @@
+package com.bravepeople.onggiyonggi.extension.home
+
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetStoreDto
+import com.bravepeople.onggiyonggi.data.response_dto.ResponseGoogleMapsSearchDto
+import com.bravepeople.onggiyonggi.extension.GetStoreTimeState
+
+sealed class GetStoreState {
+    data object Loading: GetStoreState()
+    data class Success(val storeDto: ResponseGetStoreDto): GetStoreState()
+    data class Error(val message:String): GetStoreState()
+}

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionAdapter.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionAdapter.kt
@@ -12,8 +12,8 @@ import coil3.Canvas
 import coil.load
 import coil.transform.Transformation
 import com.bravepeople.onggiyonggi.R
-import com.bravepeople.onggiyonggi.data.Character
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseAllCharacterDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.databinding.ItemCollectionBinding
 import timber.log.Timber
 
@@ -39,16 +39,20 @@ class CharacterCollectionAdapter(
         holder.bind(collectionList[position])
     }
 
-    fun getList(list:List<ResponseCollectionDto.Data>){
-        val collectedMap=list.associateBy {it.id }
+    fun getList(
+        list: List<ResponseCollectionDto.Data>,
+        data: List<ResponseAllCharacterDto.CharacterDetail>
+    ){
+        val collectedIdSet = list.map { it.characterResponseDto.id }.toSet()
 
-        val fullList=(1..9).map{id->
-            collectedMap[id]?.characterResponseDto ?:ResponseCollectionDto.Data.CharacterResponseDto(
-                id = id,
-                name = "",
-                description = "",
-                story = "",
-                imageURL = ""
+        val fullList = data.map { character ->
+            val isCollected = collectedIdSet.contains(character.id)
+            ResponseCollectionDto.Data.CharacterResponseDto(
+                id = character.id,
+                name = if (isCollected) character.name else "?",
+                description = if (isCollected) character.description else "",
+                story = if (isCollected) character.story else "",
+                imageURL = if (isCollected) character.imageURL else ""
             )
         }
 

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailActivity.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailActivity.kt
@@ -1,22 +1,12 @@
 package com.bravepeople.onggiyonggi.presentation.main.character
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.AnimatorSet
-import android.animation.ObjectAnimator
 import android.os.Bundle
-import android.os.PersistableBundle
-import android.view.View
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
-import coil3.load
 import com.bravepeople.onggiyonggi.R
-import com.bravepeople.onggiyonggi.data.Character
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.databinding.ActivityCharacterCollectionDetailBinding
-import kotlinx.serialization.json.Json
-import timber.log.Timber
 
 class CharacterCollectionDetailActivity : AppCompatActivity() {
     private lateinit var binding: ActivityCharacterCollectionDetailBinding

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailAdapter.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailAdapter.kt
@@ -3,9 +3,7 @@ package com.bravepeople.onggiyonggi.presentation.main.character
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import com.bravepeople.onggiyonggi.data.Character
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
-import okhttp3.internal.notify
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 
 class CharacterCollectionDetailAdapter(
     activity: FragmentActivity,

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailFragment.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterCollectionDetailFragment.kt
@@ -10,8 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import coil.load
-import com.bravepeople.onggiyonggi.data.Character
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseCollectionDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseCollectionDto
 import com.bravepeople.onggiyonggi.databinding.FragmentCharacterCollectionDetailBinding
 import timber.log.Timber
 

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterFragment.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterFragment.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import coil.load
 import com.bravepeople.onggiyonggi.R
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
 import com.bravepeople.onggiyonggi.databinding.FragmentCharacterBinding
 import com.bravepeople.onggiyonggi.extension.character.GetPetState
 import com.bravepeople.onggiyonggi.extension.character.LevelUpState
@@ -368,6 +368,7 @@ class CharacterFragment : Fragment() {
 
                                 setAffectionProgressWithAnimation(affectionLevel) {
                                     if (affectionLevel >= 100 && !isLaunchingMaxActivity) {
+                                        isLaunchingMaxActivity=true
                                         val intent = Intent(
                                             requireContext(),
                                             CharacterMaxActivity::class.java

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterMaxActivity.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/character/CharacterMaxActivity.kt
@@ -9,13 +9,11 @@ import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.activity.addCallback
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.lifecycleScope
 import coil.load
 import com.bravepeople.onggiyonggi.R
-import com.bravepeople.onggiyonggi.data.response_dto.ResponseGetPetDto
+import com.bravepeople.onggiyonggi.data.response_dto.character.ResponseGetPetDto
 import com.bravepeople.onggiyonggi.databinding.ActivityCharacterMaxBinding
 import com.bravepeople.onggiyonggi.extension.character.AddMaxState
 import dagger.hilt.android.AndroidEntryPoint
@@ -124,14 +122,10 @@ class CharacterMaxActivity : AppCompatActivity() {
             duration = 500
         }
 
-        binding.btnCollection.visibility = View.VISIBLE
-        val fadeInButton = ObjectAnimator.ofFloat(binding.btnCollection, "alpha", 0f, 1f).apply {
-            duration = 500
-        }
 
         // 애니메이션 세트로 실행
         AnimatorSet().apply {
-            playTogether(slideAnimator, fadeInAnimator, fadeInButton)
+            playTogether(slideAnimator, fadeInAnimator)
             start()
         }
 

--- a/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bravepeople/onggiyonggi/presentation/main/home/HomeViewModel.kt
@@ -1,0 +1,64 @@
+package com.bravepeople.onggiyonggi.presentation.main.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bravepeople.onggiyonggi.data.repositoryImpl.BaseRepositoryImpl
+import com.bravepeople.onggiyonggi.extension.home.GetStoreState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import okhttp3.ResponseBody
+import org.json.JSONObject
+import retrofit2.HttpException
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val baseRepositoryImpl: BaseRepositoryImpl
+):ViewModel() {
+    private lateinit var accessToken:String
+
+    private val _getStoreState = MutableStateFlow<GetStoreState>(GetStoreState.Loading)
+    val getStoreState:StateFlow<GetStoreState> = _getStoreState.asStateFlow()
+
+    fun saveToken(token:String){
+        accessToken=token
+    }
+    fun getStore(latitude:Double, longitude:Double, radius:Int){
+        viewModelScope.launch {
+            accessToken?.let {
+                baseRepositoryImpl.getStore(accessToken, latitude, longitude, radius).onSuccess { response->
+                    _getStoreState.value=GetStoreState.Success(response)
+                }.onFailure {
+                    _getStoreState.value=GetStoreState.Error("get store error!!")
+                    if (it is HttpException) {
+                        try {
+                            val errorBody: ResponseBody? = it.response()?.errorBody()
+                            val errorBodyString = errorBody?.string() ?: ""
+                            httpError(errorBodyString)
+                        } catch (e: Exception) {
+                            // JSON 파싱 실패 시 로깅
+                            Timber.e("Error parsing error body: ${e}")
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+
+    private fun httpError(errorBody: String) {
+        // 전체 에러 바디를 로깅하여 디버깅
+        Timber.e("Full error body: $errorBody")
+
+        // JSONObject를 사용하여 메시지 추출
+        val jsonObject = JSONObject(errorBody)
+        val errorMessage = jsonObject.optString("message", "Unknown error")
+
+        // 추출된 에러 메시지 로깅
+        Timber.e("Error message: $errorMessage")
+    }
+}

--- a/app/src/main/res/layout/activity_character_max.xml
+++ b/app/src/main/res/layout/activity_character_max.xml
@@ -16,19 +16,6 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>
 
-    <ImageView
-        android:id="@+id/btn_collection"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginEnd="30dp"
-        android:layout_marginTop="15dp"
-        android:background="@drawable/ic_collection_gray_91"
-        android:visibility="gone"
-        app:layout_constraintDimensionRatio="1:1"
-        app:layout_constraintWidth_percent="0.13"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_card"
         android:layout_width="0dp"


### PR DESCRIPTION
- 컬렉션의 전체 캐릭터 조회 api 추가
- km단위로 서버에서 가게 위치 받아오는 api 추가 (최소 1km)
- 반경이 클 때는 가까운 거리의 가게 중 랭크가 높고, 배열의 앞쪽에 있는 가게를 마커로 표시
- 반경이 작을 때는 20m일때, 50m일때, 100m일때, 200m일때, 500m일때로 나누어 가게를 더 많이 표시
- 마커가 나타날 때, 사라질 때 fade 애니메이션 적용

![image](https://github.com/user-attachments/assets/d1c8c0fa-3e6f-4d2c-9cbb-4b3b6f345884)
